### PR TITLE
Chore: add catalog info [SC-243205]

### DIFF
--- a/.infra/catalog-info.yaml
+++ b/.infra/catalog-info.yaml
@@ -1,0 +1,20 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    circleci.com/project-slug: github/ThirtyMadison/go-links
+    github.com/project-slug: ThirtyMadison/go-links
+  description: Go Links
+  labels:
+    has_frontend: 'False'
+  links:
+  - icon: github
+    title: Github
+    url: https://github.com/ThirtyMadison/go-links
+  name: go-links
+  tags:
+  - python
+spec:
+  dependsOn: []
+  lifecycle: production
+  type: service


### PR DESCRIPTION
Add catalog info https://app.shortcut.com/thirty-madison/story/243205/set-codeowners-catalog-info-for-every-repo